### PR TITLE
Added a coverage config file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 processing/testing/*
+cover/
 
 # Front-End #
 #############

--- a/processing/.coveragerc
+++ b/processing/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit=testing/*


### PR DESCRIPTION
This should help omit the testing directories from code coverage.  You can run coverage like this: 

```
cd processing
nosetests --with-coverage --cover-package=. --cover-html
```

The `.` in the --coverage-package option indicates the current directory, so essentially we're saying only run a coverage report for things in the current directory.  Otherwise, it will try to run reports for the requests module, the urllib library, etc.  

Everything else should be like we discussed, we were so very close during our working session!!!

If all goes well, you'll see a report like this: 

```
Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
aggregation                491    491     0%   1-617
aggretation                493    493     0%   1-634
api_test                    13      0   100%   
blerp                        5      5     0%   1-6
builder                    490    490     0%   1-584
connector                   18     18     0%   1-21
constructor                235    235     0%   1-297
controller                  48     48     0%   2-75
demographics_indexing      125     77    38%   28, 33-52, 56-74, 112-124, 130-153, 157-162, 168, 173-186
file_check                  32     32     0%   1-41
geo_aggregator_full         81     81     0%   1-175
geo_aggregator_one          65     65     0%   1-143
median_age_api              17     17     0%   1-20
msa_indexing                48     48     0%   1-56
msas_state                  48     48     0%   1-61
parsing                    438    438     0%   1-533
queries                    124    124     0%   2-224
report_list                 34     34     0%   1-42
respondent_id_compiler      11     11     0%   1-16
selector                    24     24     0%   1-30
------------------------------------------------------
TOTAL                     2840   2779     2%   
----------------------------------------------------------------------
```

Also, there will be a coverage html report under `cover/index.html`.  If you click on `demogrpahics_indexing` it should should take you to a highlighted view of your code, where green indicates covered code and red indicates code missing tests.  

Good luck! 
